### PR TITLE
Remove rss feed command

### DIFF
--- a/src/main/java/org/infobourg/betterrss/commands/CommandEnum.kt
+++ b/src/main/java/org/infobourg/betterrss/commands/CommandEnum.kt
@@ -1,0 +1,8 @@
+package org.infobourg.betterrss.commands
+
+enum class CommandEnum(val command: String) {
+    LIST("list"),
+    HELP("help"),
+    ADD("add"),
+    REMOVE("remove")
+}

--- a/src/main/java/org/infobourg/betterrss/commands/CommandHandler.kt
+++ b/src/main/java/org/infobourg/betterrss/commands/CommandHandler.kt
@@ -1,0 +1,9 @@
+package org.infobourg.betterrss.commands
+
+import com.slack.api.bolt.context.builtin.SlashCommandContext
+import com.slack.api.bolt.request.builtin.SlashCommandRequest
+import com.slack.api.bolt.response.Response
+
+interface CommandHandler {
+    fun handleCommand(request:SlashCommandRequest): (SlashCommandContext) -> Response;
+}

--- a/src/main/java/org/infobourg/betterrss/commands/RssFeedCommandHandler.kt
+++ b/src/main/java/org/infobourg/betterrss/commands/RssFeedCommandHandler.kt
@@ -10,24 +10,22 @@ import org.bson.types.ObjectId
 import org.infobourg.betterrss.services.RssFeedService
 import org.springframework.stereotype.Component
 
+typealias  Handle = (args: List<String>, request: SlashCommandRequest) -> (SlashCommandContext) -> Response
+
 @Component
 class RssFeedCommandHandler(private val rssFeedService: RssFeedService) : CommandHandler {
 
-    private val commandHandle: Array<CommandHandle> = arrayOf(
-            CommandHandle(commandType = CommandEnum.LIST, handle = this::list),
-            CommandHandle(commandType = CommandEnum.REMOVE, handle = this::remove)
-    )
 
     override fun handleCommand(request: SlashCommandRequest): (SlashCommandContext) -> Response {
         val args = request.payload?.text?.split(" ") ?: listOf()
-        if (args.isEmpty()) return this.help();
+        if (args.isEmpty()) return this.help(args, request);
         val cmd = commandHandle.find { c -> c.commandType.command == args[0] }
-        return if (cmd != null) cmd.handle(args, request) else this.help();
+        return if (cmd != null) cmd.handle(args, request) else this.help(args, request)
     }
 
-    private fun list(args: List<String>, request: SlashCommandRequest): (SlashCommandContext) -> Response {
+    private val list: Handle = list@{ _: List<String>, _: SlashCommandRequest ->
         val rssFeed = rssFeedService.findAll()
-        return { context ->
+        return@list { context: SlashCommandContext ->
             context.ack(asBlocks(
                     section { s -> s.text(plainText("List of rss flux")) },
                     section { s -> s.text(markdownText(rssFeed.joinToString("\n") { rss -> "- ${rss.id} : ${rss.link}" })) }
@@ -35,10 +33,10 @@ class RssFeedCommandHandler(private val rssFeedService: RssFeedService) : Comman
         }
     }
 
-    private fun remove(args: List<String>, request: SlashCommandRequest): (SlashCommandContext) -> Response {
-        if(args.size < 2) {
+    private val remove: Handle = remove@{ args: List<String>, _: SlashCommandRequest ->
+        if (args.size < 2) {
             val rssFeed = rssFeedService.findAll()
-            return { context ->
+            return@remove { context ->
                 context.ack(asBlocks(
                         section { section ->
                             section
@@ -61,25 +59,30 @@ class RssFeedCommandHandler(private val rssFeedService: RssFeedService) : Comman
             }
         } else {
             val arg = args[1];
-            if(ObjectId.isValid(arg)) {
+            if (ObjectId.isValid(arg)) {
                 println("$arg is valid")
                 // If is an id
-                if(!rssFeedService.existsById(arg))
-                    return  {ctx -> ctx.ack("No Rss Feed with this id")}
+                if (!rssFeedService.existsById(arg))
+                    return@remove { ctx -> ctx.ack("No Rss Feed with this id") }
                 rssFeedService.removeByIdRssFeed((arg))
             } else {
                 // Looking or url
-                if(!rssFeedService.existsByLink(arg))
-                    return  {ctx -> ctx.ack("No Rss Feed with this link")}
+                if (!rssFeedService.existsByLink(arg))
+                    return@remove { ctx -> ctx.ack("No Rss Feed with this link") }
                 rssFeedService.removeByLink(arg)
             }
-            return { context -> context.ack("Rss Feed removed")}
+            return@remove { context -> context.ack("Rss Feed removed") }
         }
     }
 
-    private fun help(): (SlashCommandContext) -> Response {
-        return { context -> context.ack("Error in the command") }
+    private val help: Handle = help@{ _: List<String>, _: SlashCommandRequest ->
+        return@help { context -> context.ack("Error in the command") }
     }
+
+    private val commandHandle: Array<CommandHandle> = arrayOf(
+            CommandHandle(commandType = CommandEnum.LIST, handle = this.list),
+            CommandHandle(commandType = CommandEnum.REMOVE, handle = this.remove)
+    )
 }
 
 data class CommandHandle(

--- a/src/main/java/org/infobourg/betterrss/commands/RssFeedCommandHandler.kt
+++ b/src/main/java/org/infobourg/betterrss/commands/RssFeedCommandHandler.kt
@@ -1,0 +1,84 @@
+package org.infobourg.betterrss.commands
+
+import com.slack.api.bolt.context.builtin.SlashCommandContext
+import com.slack.api.bolt.request.builtin.SlashCommandRequest
+import com.slack.api.bolt.response.Response
+import com.slack.api.model.block.Blocks.*
+import com.slack.api.model.block.composition.BlockCompositions.*
+import com.slack.api.model.block.element.BlockElements.*
+import org.bson.types.ObjectId
+import org.infobourg.betterrss.services.RssFeedService
+import org.springframework.stereotype.Component
+
+@Component
+class RssFeedCommandHandler(private val rssFeedService: RssFeedService) : CommandHandler {
+
+    private val commandHandle: Array<CommandHandle> = arrayOf(
+            CommandHandle(commandType = CommandEnum.LIST, handle = this::list),
+            CommandHandle(commandType = CommandEnum.REMOVE, handle = this::remove)
+    )
+
+    override fun handleCommand(request: SlashCommandRequest): (SlashCommandContext) -> Response {
+        val args = request.payload?.text?.split(" ") ?: listOf()
+        if (args.isEmpty()) return this.help();
+        val cmd = commandHandle.find { c -> c.commandType.command == args[0] }
+        return if (cmd != null) cmd.handle(args, request) else this.help();
+    }
+
+    private fun list(args: List<String>, request: SlashCommandRequest): (SlashCommandContext) -> Response {
+        val rssFeed = rssFeedService.findAll()
+        return { context ->
+            context.ack(asBlocks(
+                    section { s -> s.text(plainText("List of rss flux")) },
+                    section { s -> s.text(markdownText(rssFeed.joinToString("\n") { rss -> "- ${rss.id} : ${rss.link}" })) }
+            ))
+        }
+    }
+
+    private fun remove(args: List<String>, request: SlashCommandRequest): (SlashCommandContext) -> Response {
+        if(args.size < 2) {
+            val rssFeed = rssFeedService.findAll()
+            return { context ->
+                context.ack(asBlocks(
+                        section { section ->
+                            section
+                                    .text(markdownText("Choose the rss feed to remove"))
+                                    .accessory(
+                                            staticSelect { staticSelect ->
+                                                staticSelect
+                                                        .placeholder(plainText { pt -> pt.text("Choose feed").emoji(true) })
+                                                        .options(rssFeed.map { rss ->
+                                                            option { option ->
+                                                                option
+                                                                        .text(plainText(rss.link))
+                                                                        .value(rss.id)
+                                                            }
+                                                        })
+                                            }
+                                    )
+                        }
+                ))
+            }
+        } else {
+            val arg = args[1];
+            if(ObjectId.isValid(arg)) {
+                println("$arg is valid")
+                // If is an id
+                rssFeedService.removeByIdRssFeed((arg))
+            } else {
+                // Looking or url
+                rssFeedService.removeByLink(arg)
+            }
+            return { context -> context.ack("Rss Feed removed")}
+        }
+    }
+
+    private fun help(): (SlashCommandContext) -> Response {
+        return { context -> context.ack("Error in the command") }
+    }
+}
+
+data class CommandHandle(
+        val commandType: CommandEnum,
+        val handle: (List<String>, SlashCommandRequest) -> (SlashCommandContext) -> Response
+)

--- a/src/main/java/org/infobourg/betterrss/commands/RssFeedCommandHandler.kt
+++ b/src/main/java/org/infobourg/betterrss/commands/RssFeedCommandHandler.kt
@@ -64,9 +64,13 @@ class RssFeedCommandHandler(private val rssFeedService: RssFeedService) : Comman
             if(ObjectId.isValid(arg)) {
                 println("$arg is valid")
                 // If is an id
+                if(!rssFeedService.existsById(arg))
+                    return  {ctx -> ctx.ack("No Rss Feed with this id")}
                 rssFeedService.removeByIdRssFeed((arg))
             } else {
                 // Looking or url
+                if(!rssFeedService.existsByLink(arg))
+                    return  {ctx -> ctx.ack("No Rss Feed with this link")}
                 rssFeedService.removeByLink(arg)
             }
             return { context -> context.ack("Rss Feed removed")}

--- a/src/main/java/org/infobourg/betterrss/commands/RssFeedSlashCommand.kt
+++ b/src/main/java/org/infobourg/betterrss/commands/RssFeedSlashCommand.kt
@@ -1,0 +1,13 @@
+package org.infobourg.betterrss.commands
+
+import org.infobourg.betterrss.slack.SlashCommand
+import org.springframework.stereotype.Component
+
+@Component
+class RssFeedSlashCommand(private val commandHandler: CommandHandler) : SlashCommand(
+        command = "/rss",
+        handler =  {
+    request, context ->
+           commandHandler.handleCommand(request)(context)
+}
+)

--- a/src/main/java/org/infobourg/betterrss/repositories/RssFeedRepository.kt
+++ b/src/main/java/org/infobourg/betterrss/repositories/RssFeedRepository.kt
@@ -8,4 +8,5 @@ interface RssFeedRepository : MongoRepository<RssFeed, String> {
     fun findByIdWorkspace(idWorkspace: String): List<RssFeed>
     fun findByIdThread(idThread: String): List<RssFeed>
     fun deleteByLink(link: String)
+    fun existsByLink(link: String): Boolean
 }

--- a/src/main/java/org/infobourg/betterrss/repositories/RssFeedRepository.kt
+++ b/src/main/java/org/infobourg/betterrss/repositories/RssFeedRepository.kt
@@ -7,4 +7,5 @@ interface RssFeedRepository : MongoRepository<RssFeed, String> {
     fun findByIdChannel(idChannel: String): List<RssFeed>
     fun findByIdWorkspace(idWorkspace: String): List<RssFeed>
     fun findByIdThread(idThread: String): List<RssFeed>
+    fun deleteByLink(link: String)
 }

--- a/src/main/java/org/infobourg/betterrss/services/RssFeedService.kt
+++ b/src/main/java/org/infobourg/betterrss/services/RssFeedService.kt
@@ -6,9 +6,11 @@ import org.springframework.stereotype.Service
 
 
 @Service
-class RssFeedService(var rssFeedRepository: RssFeedRepository){
+class RssFeedService(private var rssFeedRepository: RssFeedRepository){
     fun findAll(): List<RssFeed> = rssFeedRepository.findAll()
     fun findByIdWorkspace(idWorkspace: String): List<RssFeed> = rssFeedRepository.findByIdWorkspace(idWorkspace)
     fun findByIdChannel(idChannel: String): List<RssFeed> = rssFeedRepository.findByIdChannel(idChannel)
     fun findByIdThread(idThread: String): List<RssFeed> = rssFeedRepository.findByIdThread(idThread)
+    fun removeByIdRssFeed(idRssFeed: String) = rssFeedRepository.deleteById(idRssFeed)
+    fun removeByLink(idRssFeed: String) = rssFeedRepository.deleteByLink(idRssFeed)
 }

--- a/src/main/java/org/infobourg/betterrss/services/RssFeedService.kt
+++ b/src/main/java/org/infobourg/betterrss/services/RssFeedService.kt
@@ -3,11 +3,14 @@ package org.infobourg.betterrss.services
 import org.infobourg.betterrss.models.RssFeed
 import org.infobourg.betterrss.repositories.RssFeedRepository
 import org.springframework.stereotype.Service
+import java.util.*
 
 
 @Service
 class RssFeedService(private var rssFeedRepository: RssFeedRepository){
     fun findAll(): List<RssFeed> = rssFeedRepository.findAll()
+    fun existsById(id: String): Boolean = rssFeedRepository.existsById(id)
+    fun existsByLink(link: String): Boolean = rssFeedRepository.existsByLink(link)
     fun findByIdWorkspace(idWorkspace: String): List<RssFeed> = rssFeedRepository.findByIdWorkspace(idWorkspace)
     fun findByIdChannel(idChannel: String): List<RssFeed> = rssFeedRepository.findByIdChannel(idChannel)
     fun findByIdThread(idThread: String): List<RssFeed> = rssFeedRepository.findByIdThread(idThread)

--- a/src/main/java/org/infobourg/betterrss/slack/SlackExt.kt
+++ b/src/main/java/org/infobourg/betterrss/slack/SlackExt.kt
@@ -2,9 +2,12 @@ package org.infobourg.betterrss.slack
 
 import com.slack.api.model.block.InputBlock
 import com.slack.api.model.block.LayoutBlock
+import com.slack.api.model.block.SectionBlock
+import com.slack.api.model.block.composition.OptionObject
 import com.slack.api.model.block.composition.PlainTextObject
 import com.slack.api.model.block.element.ConversationsSelectElement
 import com.slack.api.model.block.element.PlainTextInputElement
+import com.slack.api.model.block.element.StaticSelectElement
 import com.slack.api.model.view.View
 import com.slack.api.model.view.ViewClose
 import com.slack.api.model.view.ViewSubmit
@@ -12,6 +15,10 @@ import com.slack.api.model.view.ViewTitle
 
 fun view(builder: View.() -> Unit): View {
     return View().apply(builder)
+}
+
+fun block(builder: BlockBuilder.() -> Unit): List<LayoutBlock> {
+    return BlockBuilder().apply(builder).layouts;
 }
 
 fun View.title(builder: ViewTitle.() -> Unit) {
@@ -40,6 +47,10 @@ class BlockBuilder {
     fun input(builder: InputBlock.() -> Unit) {
         layouts.add(InputBlock().apply(builder))
     }
+
+    fun section(builder: SectionBlock.() -> Unit) {
+        layouts.add(SectionBlock().apply(builder))
+    }
 }
 
 fun plainTextInput(builder: PlainTextInputElement.() -> Unit): PlainTextInputElement {
@@ -52,4 +63,12 @@ fun plainText(builder: PlainTextObject.() -> Unit): PlainTextObject {
 
 fun conversationsSelect(builder: ConversationsSelectElement.() -> Unit): ConversationsSelectElement {
     return ConversationsSelectElement().apply(builder)
+}
+
+fun staticSelect(builder: StaticSelectElement.() -> Unit): StaticSelectElement {
+    return StaticSelectElement().apply(builder)
+}
+
+fun option(build: OptionObject.() -> Unit): OptionObject {
+    return OptionObject().apply(build)
 }

--- a/src/main/java/org/infobourg/betterrss/slack/SlashCommand.kt
+++ b/src/main/java/org/infobourg/betterrss/slack/SlashCommand.kt
@@ -3,7 +3,6 @@ package org.infobourg.betterrss.slack
 import com.slack.api.bolt.context.builtin.SlashCommandContext
 import com.slack.api.bolt.request.builtin.SlashCommandRequest
 import com.slack.api.bolt.response.Response
-import org.infobourg.betterrss.rss.RssCommandHandler
 
 abstract class SlashCommand(
         command: String,

--- a/src/main/java/org/infobourg/betterrss/slack/SlashCommand.kt
+++ b/src/main/java/org/infobourg/betterrss/slack/SlashCommand.kt
@@ -3,6 +3,7 @@ package org.infobourg.betterrss.slack
 import com.slack.api.bolt.context.builtin.SlashCommandContext
 import com.slack.api.bolt.request.builtin.SlashCommandRequest
 import com.slack.api.bolt.response.Response
+import org.infobourg.betterrss.rss.RssCommandHandler
 
 abstract class SlashCommand(
         command: String,


### PR DESCRIPTION
2 new commands:
- /rss list
- /rss remove

# rss list
List all rss feed with their id (that can be used to delete it)

# rss remove
3 ways to use it
- without args (/rss remove):
  - show a prompt with a list of all the rss feed (not implemented yet, just the visual)
- with id arg (/rss remove 5f070641a203de33bc177ad0)
- with link (/rss remove http://android-developers.blogspot.com/atom.xml)

close #4 